### PR TITLE
Add CORS filter

### DIFF
--- a/adaptor-bugzilla/src/main/java/se/kth/md/it/bcm/servlet/OslcCorsFilter.java
+++ b/adaptor-bugzilla/src/main/java/se/kth/md/it/bcm/servlet/OslcCorsFilter.java
@@ -1,0 +1,35 @@
+package se.kth.md.it.bcm.servlet;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.ext.Provider;
+import java.io.IOException;
+
+/**
+ * Allows OSLC requests to be made to the server from the web browser from another domain.
+ */
+@Provider
+public class OslcCorsFilter implements ContainerResponseFilter {
+
+    @Override
+    public void filter(ContainerRequestContext requestContext,
+                       ContainerResponseContext responseContext) throws IOException {
+        String originAllow = "*";
+        final String requestOrigin = requestContext.getHeaderString("Origin");
+        if (requestOrigin != null) {
+            //needed to enable Access-Control-Allow-Credentials
+            originAllow = requestOrigin;
+        }
+        responseContext.getHeaders().add(
+                "Access-Control-Allow-Origin", originAllow);
+        responseContext.getHeaders().add(
+                "Access-Control-Allow-Credentials", "true");
+        responseContext.getHeaders().add(
+                "Access-Control-Allow-Headers",
+                "origin, content-type, accept, authorization, oslc-core-version, Configuration-Context, OSLC-Configuration-Context");
+        responseContext.getHeaders().add(
+                "Access-Control-Allow-Methods",
+                "GET, POST, PUT, DELETE, OPTIONS, HEAD");
+    }
+}


### PR DESCRIPTION
Otherwise the CF dialog in NinaCRM does not work.

Blocked by #30 because `ContainerResponseFilter` requires JAX-RS 2.0 support.